### PR TITLE
Delete comments on the talk before deleting the talk

### DIFF
--- a/src/main/java/io/cfp/repository/CommentRepo.java
+++ b/src/main/java/io/cfp/repository/CommentRepo.java
@@ -33,6 +33,8 @@ public interface CommentRepo extends JpaRepository<Comment, Integer> {
 
     void deleteByIdAndEventId(int integer, String eventId);
 
+    void deleteByTalkId(int talkId);
+
     /**
      * Retrieve a comment for the user which are visible to user
      * @param commentId Id of the comment to retrieve

--- a/src/main/java/io/cfp/service/TalkAdminService.java
+++ b/src/main/java/io/cfp/service/TalkAdminService.java
@@ -31,6 +31,7 @@ import java.util.List;
 import java.util.Map;
 import java.util.stream.Collectors;
 
+import io.cfp.repository.*;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
@@ -43,11 +44,6 @@ import io.cfp.entity.Event;
 import io.cfp.entity.Rate;
 import io.cfp.entity.Talk;
 import io.cfp.entity.User;
-import io.cfp.repository.FormatRepo;
-import io.cfp.repository.RateRepo;
-import io.cfp.repository.TalkRepo;
-import io.cfp.repository.TrackRepo;
-import io.cfp.repository.UserRepo;
 import io.cfp.service.admin.user.AdminUserService;
 import ma.glasnost.orika.MapperFacade;
 
@@ -72,6 +68,9 @@ public class TalkAdminService {
 
     @Autowired
     private TrackRepo trackRepo;
+
+    @Autowired
+    private CommentRepo commentRepo;
 
     @Autowired
     private AdminUserService adminUserService;
@@ -189,6 +188,7 @@ public class TalkAdminService {
     public TalkAdmin delete(int talkId) {
         Talk talk = talkRepo.findByIdAndEventId(talkId, Event.current());
         TalkAdmin deleted = mapper.map(talk, TalkAdmin.class);
+        commentRepo.deleteByTalkId(talkId); // fix to issue #122
         talkRepo.delete(talk);
         return deleted;
     }


### PR DESCRIPTION
Quick (and dirty?) fix to issue #122. Maybe there was a way to do this with an `@Query` annotation…

Closes #122